### PR TITLE
remove nested parallel, run multi-thread without omp env

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,17 @@ If so, you can comment the following line in `pcm/Makefile`:
 CXXFLAGS += -DPCM_USE_PERF
 ```
 
+# OpenMP
+PiBench uses OpenMP internally for multithreading.
+The environment variable `OMP_NESTED=true` must be set to guarantee correctness.
+Check [here](https://docs.microsoft.com/en-us/cpp/parallel/openmp/reference/openmp-environment-variables?view=vs-2019#omp-nested) for details.
+
+Other environment variables such as [`OMP_PLACES`](https://gnu.huihoo.org/gcc/gcc-4.9.4/libgomp/OMP_005fPLACES.html#OMP_005fPLACES) and [`OMP_PROC_BIND`](https://gnu.huihoo.org/gcc/gcc-4.9.4/libgomp/OMP_005fPROC_005fBIND.html) can be set to control the multithreaded behavior.
+
+For example:
+
+`$ OMP_PLACES=cores OMP_PROC_BIND=true OMP_NESTED=true ./PiBench [...]`
+
 # Running
 The `PiBench` executable is generated and supports the following arguments:
 ```

--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -106,6 +106,7 @@ void benchmark_t::run() noexcept
 
     float elapsed = 0.0;
     stopwatch_t sw;
+    omp_set_nested(true);
     #pragma omp parallel sections num_threads(2)
     {
         #pragma omp section // Monitor thread
@@ -152,9 +153,6 @@ void benchmark_t::run() noexcept
                     // Generate random scrambled key
                     auto key_ptr = key_generator_->next(op == operation_t::INSERT ? true : false);
 
-                    // Generate random value
-                    auto value_ptr = value_generator_.next();
-
                     switch (op)
                     {
                     case operation_t::READ:
@@ -165,13 +163,17 @@ void benchmark_t::run() noexcept
 
                     case operation_t::INSERT:
                     {
-                        auto r = tree_->insert(key_ptr, key_generator_->size(), value_ptr, opt_.value_size);
+                      // Generate random value
+                      auto value_ptr = value_generator_.next();
+                      auto r = tree_->insert(key_ptr, key_generator_->size(), value_ptr, opt_.value_size);
                         break;
                     }
 
                     case operation_t::UPDATE:
                     {
-                        auto r = tree_->update(key_ptr, key_generator_->size(), value_ptr, opt_.value_size);
+                      // Generate random value
+                      auto value_ptr = value_generator_.next();
+                      auto r = tree_->update(key_ptr, key_generator_->size(), value_ptr, opt_.value_size);
                         break;
                     }
 
@@ -206,6 +208,7 @@ void benchmark_t::run() noexcept
         }
     }
 
+    omp_set_nested(false);
     std::unique_ptr<SystemCounterState> after_sstate;
     if (opt_.enable_pcm)
     {

--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -164,16 +164,16 @@ void benchmark_t::run() noexcept
                     case operation_t::INSERT:
                     {
                       // Generate random value
-                      auto value_ptr = value_generator_.next();
-                      auto r = tree_->insert(key_ptr, key_generator_->size(), value_ptr, opt_.value_size);
+                        auto value_ptr = value_generator_.next();
+                        auto r = tree_->insert(key_ptr, key_generator_->size(), value_ptr, opt_.value_size);
                         break;
                     }
 
                     case operation_t::UPDATE:
                     {
                       // Generate random value
-                      auto value_ptr = value_generator_.next();
-                      auto r = tree_->update(key_ptr, key_generator_->size(), value_ptr, opt_.value_size);
+                        auto value_ptr = value_generator_.next();
+                        auto r = tree_->update(key_ptr, key_generator_->size(), value_ptr, opt_.value_size);
                         break;
                     }
 

--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -5,7 +5,6 @@
 #include <cassert>
 #include <iostream>
 #include <omp.h>
-#include <thread>
 
 namespace PiBench
 {
@@ -79,8 +78,6 @@ void benchmark_t::load() noexcept
               << "\tLoad time: " << elapsed << " milliseconds" << std::endl;
 }
 
-#pragma clang diagnostic push
-#pragma ide diagnostic ignored "openmp-use-default-none"
 void benchmark_t::run() noexcept
 {
     std::vector<stats_t> global_stats;
@@ -109,96 +106,107 @@ void benchmark_t::run() noexcept
 
     float elapsed = 0.0;
     stopwatch_t sw;
-    std::thread monitor_thread([&]() {
-      std::chrono::milliseconds sampling_window(opt_.sampling_ms);
-      while (!finished) {
-        std::this_thread::sleep_for(sampling_window);
-        stats_t s;
-        s.operation_count =
-            std::accumulate(local_stats.begin(), local_stats.end(), 0,
-                            [](uint64_t sum, const stats_t &curr) {
-                              return sum + curr.operation_count;
-                            });
-        global_stats.push_back(std::move(s));
-      }
-    });
-
-#pragma omp parallel num_threads(opt_.num_threads) default(shared)
+    #pragma omp parallel sections num_threads(2)
     {
-      auto tid = omp_get_thread_num();
-
-      // Initialize random seed for each thread
-      key_generator_->set_seed(opt_.rnd_seed * (tid + 1));
-
-      // Initialize insert id for each thread
-      key_generator_->current_id_ = current_id + (inserts_per_thread * tid);
-
-#pragma omp barrier
-
-#pragma omp single nowait
-      { sw.start(); }
-
-      // TODO: add warning. We expect at least 50 op per thread
-#pragma omp for schedule(nonmonotonic : dynamic, 50)
-      for (uint64_t i = 0; i < opt_.num_ops; ++i) {
-        // Generate random operation
-        auto op = op_generator_.next();
-
-        // Generate random scrambled key
-        auto key_ptr =
-            key_generator_->next(op == operation_t::INSERT ? true : false);
-
-        // Generate random value
-        auto value_ptr = value_generator_.next();
-
-        switch (op) {
-        case operation_t::READ: {
-          tree_->find(key_ptr, key_generator_->size(), value_out);
-          break;
+        #pragma omp section // Monitor thread
+        {
+            std::chrono::milliseconds sampling_window(opt_.sampling_ms);
+            while (!finished)
+            {
+                std::this_thread::sleep_for(sampling_window);
+                stats_t s;
+                s.operation_count = std::accumulate(local_stats.begin(), local_stats.end(), 0,
+                                                    [](uint64_t sum, const stats_t& curr) {
+                                                        return sum + curr.operation_count;
+                                                    });
+                global_stats.push_back(std::move(s));
+            }
         }
 
-        case operation_t::INSERT: {
-          auto r = tree_->insert(key_ptr, key_generator_->size(), value_ptr,
-                                 opt_.value_size);
-          break;
-        }
+        #pragma omp section // Worker threads
+        {
+            #pragma omp parallel num_threads(opt_.num_threads)
+            {
+                auto tid = omp_get_thread_num();
 
-        case operation_t::UPDATE: {
-          auto r = tree_->update(key_ptr, key_generator_->size(), value_ptr,
-                                 opt_.value_size);
-          break;
-        }
+                // Initialize random seed for each thread
+                key_generator_->set_seed(opt_.rnd_seed * (tid + 1));
 
-        case operation_t::REMOVE: {
-          auto r = tree_->remove(key_ptr, key_generator_->size());
-          break;
-        }
+                // Initialize insert id for each thread
+                key_generator_->current_id_ = current_id + (inserts_per_thread * tid);
 
-        case operation_t::SCAN: {
-          auto r = tree_->scan(key_ptr, key_generator_->size(), opt_.scan_size,
-                               values_out);
-          break;
-        }
+                #pragma omp barrier
 
-        default:
-          std::cout << "Error: unknown operation!" << std::endl;
-          exit(0);
-          break;
-        }
-        auto tid = omp_get_thread_num();
-        ++local_stats[tid].operation_count;
-      }
+                #pragma omp single nowait
+                {
+                    sw.start();
+                }
 
-// Get elapsed time and signal monitor thread to finish.
-#pragma omp single nowait
-    {
-      elapsed = sw.elapsed<std::chrono::milliseconds>();
-      finished = true;
+                // TODO: add warning. We expect at least 50 op per thread
+                #pragma omp for schedule(nonmonotonic : dynamic, 50)
+                for (uint64_t i = 0; i < opt_.num_ops; ++i)
+                {
+                    // Generate random operation
+                    auto op = op_generator_.next();
+
+                    // Generate random scrambled key
+                    auto key_ptr = key_generator_->next(op == operation_t::INSERT ? true : false);
+
+                    // Generate random value
+                    auto value_ptr = value_generator_.next();
+
+                    switch (op)
+                    {
+                    case operation_t::READ:
+                    {
+                        tree_->find(key_ptr, key_generator_->size(), value_out);
+                        break;
+                    }
+
+                    case operation_t::INSERT:
+                    {
+                        auto r = tree_->insert(key_ptr, key_generator_->size(), value_ptr, opt_.value_size);
+                        break;
+                    }
+
+                    case operation_t::UPDATE:
+                    {
+                        auto r = tree_->update(key_ptr, key_generator_->size(), value_ptr, opt_.value_size);
+                        break;
+                    }
+
+                    case operation_t::REMOVE:
+                    {
+                        auto r = tree_->remove(key_ptr, key_generator_->size());
+                        break;
+                    }
+
+                    case operation_t::SCAN:
+                    {
+                        auto r = tree_->scan(key_ptr, key_generator_->size(), opt_.scan_size, values_out);
+                        break;
+                    }
+
+                    default:
+                        std::cout << "Error: unknown operation!" << std::endl;
+                        exit(0);
+                        break;
+                    }
+                    auto tid = omp_get_thread_num();
+                    ++local_stats[tid].operation_count;
+                }
+
+                // Get elapsed time and signal monitor thread to finish.
+                #pragma omp single nowait
+                {
+                    elapsed = sw.elapsed<std::chrono::milliseconds>();
+                    finished = true;
+                }
+            }
+        }
     }
-  }
 
-  monitor_thread.join();
-  std::unique_ptr<SystemCounterState> after_sstate;
+    std::unique_ptr<SystemCounterState> after_sstate;
     if (opt_.enable_pcm)
     {
         after_sstate = std::make_unique<SystemCounterState>();
@@ -230,7 +238,6 @@ void benchmark_t::run() noexcept
     for (auto s : global_stats)
         std::cout << "\t" << s.operation_count << std::endl;
 }
-#pragma clang diagnostic pop
 } // namespace PiBench
 
 namespace std


### PR DESCRIPTION
current nested loop needs a OMP_NESTED=true environment variable, this patch tries to get rid of it.

Basically removed the nested omp parallel, which I believe can improve readability as well. 

I used the std::thread to create monitoring job.

partly solved https://github.com/wangtzh/pibench/issues/8