### PR TITLE
Output Polishing and more

### DIFF
--- a/include/benchmark.hpp
+++ b/include/benchmark.hpp
@@ -33,6 +33,9 @@ enum class distribution_t : uint8_t
  */
 struct options_t
 {
+    /// Name of tree library file used to run the benchmark against.
+    std::string library_file = "";
+
     /// Number of records to insert into tree during 'load' phase.
     uint64_t num_records;
 

--- a/include/benchmark.hpp
+++ b/include/benchmark.hpp
@@ -16,6 +16,8 @@
 namespace PiBench
 {
 
+void print_environment();
+
 /**
  * @brief Supported random number distributions.
  *

--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -78,6 +78,7 @@ void benchmark_t::load() noexcept
         auto value_ptr = value_generator_.next();
 
         auto r = tree_->insert(key_ptr, key_generator_->size(), value_ptr, opt_.value_size);
+        assert(r);
     }
     auto elapsed = sw.elapsed<std::chrono::milliseconds>();
 
@@ -174,7 +175,8 @@ void benchmark_t::run() noexcept
                     {
                     case operation_t::READ:
                     {
-                        tree_->find(key_ptr, key_generator_->size(), value_out);
+                        auto r = tree_->find(key_ptr, key_generator_->size(), value_out);
+                        assert(r);
                         break;
                     }
 
@@ -183,6 +185,7 @@ void benchmark_t::run() noexcept
                         // Generate random value
                         auto value_ptr = value_generator_.next();
                         auto r = tree_->insert(key_ptr, key_generator_->size(), value_ptr, opt_.value_size);
+                        assert(r);
                         break;
                     }
 
@@ -191,18 +194,21 @@ void benchmark_t::run() noexcept
                         // Generate random value
                         auto value_ptr = value_generator_.next();
                         auto r = tree_->update(key_ptr, key_generator_->size(), value_ptr, opt_.value_size);
+                        assert(r);
                         break;
                     }
 
                     case operation_t::REMOVE:
                     {
                         auto r = tree_->remove(key_ptr, key_generator_->size());
+                        assert(r);
                         break;
                     }
 
                     case operation_t::SCAN:
                     {
                         auto r = tree_->scan(key_ptr, key_generator_->size(), opt_.scan_size, values_out);
+                        assert(r);
                         break;
                     }
 

--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -316,6 +316,7 @@ std::ostream& operator<<(std::ostream& os, const PiBench::options_t& opt)
 {
     os << "Benchmark Options:"
        << "\n"
+       << "\tTarget: " << opt.library_file << "\n"
        << "\t# Records: " << opt.num_records << "\n"
        << "\t# Operations: " << opt.num_ops << "\n"
        << "\t# Threads: " << opt.num_threads << "\n"

--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -320,6 +320,7 @@ std::ostream& operator<<(std::ostream& os, const PiBench::options_t& opt)
        << "\t# Operations: " << opt.num_ops << "\n"
        << "\t# Threads: " << opt.num_threads << "\n"
        << "\tSampling: " << opt.sampling_ms << " ms\n"
+       << "\tLatency: " << opt.latency_sampling << "\n"
        << "\tKey prefix: " << opt.key_prefix << "\n"
        << "\tKey size: " << opt.key_size << "\n"
        << "\tValue size: " << opt.value_size << "\n"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,7 +15,6 @@ using namespace PiBench;
 int main(int argc, char** argv)
 {
     // Parse command line arguments
-    std::string library_file;
     options_t opt;
     tree_options_t tree_opt;
     try
@@ -89,7 +88,7 @@ int main(int argc, char** argv)
 
         if (result.count("input"))
         {
-            library_file = result["input"].as<std::string>();
+            opt.library_file = result["input"].as<std::string>();
         }
         else
         {
@@ -285,7 +284,7 @@ int main(int argc, char** argv)
     tree_opt.value_size = opt.value_size;
     tree_opt.num_threads = opt.num_threads;
 
-    library_loader_t lib(library_file);
+    library_loader_t lib(opt.library_file);
     tree_api* tree = lib.create_tree(tree_opt);
     if(tree == nullptr)
     {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -277,7 +277,8 @@ int main(int argc, char** argv)
         exit(1);
     }
 
-    // Print options
+    // Print env and options
+    print_environment();
     std::cout << opt << std::endl;
 
     tree_opt.key_size = opt.key_prefix.size() + opt.key_size;


### PR DESCRIPTION
The following changes are applied:

- Assertions to check that operations return success in return mode
- Print latency sampling rate in options
- Making stlmap_wrapper thread safe (global mutex, so not scaling)
- Printing benchmark target in options
- Printing some environment options before benchmark options (CPU, Kernel, Cache, etc).