### PR TITLE
Adding libomp5 to Clang build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,13 +46,13 @@ jobs:
       Clang-6.0 Debug:
         CC: clang-6.0
         CXX: clang++-6.0
-        Packages: clang-6.0 libomp-dev
+        Packages: clang-6.0 libomp5 libomp-dev
         BuildType: Debug
 
       Clang-6.0 Release:
         CC: clang-6.0
         CXX: clang++-6.0
-        Packages: clang-6.0 libomp-dev
+        Packages: clang-6.0 libomp5 libomp-dev
         BuildType: Release
 
   steps:


### PR DESCRIPTION
libomp5 is a dependency of libomp-dev