### PR TITLE
Increasing CMake version to 3.14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(PiBench)
 
 set(CMAKE_CXX_STANDARD 17)


### PR DESCRIPTION
Version 3.14 is required to support FetchContent_Declare and
FetchContent_MakeAvailable.