### PR TITLE
Parse "num_operations" if "mode" is not provided

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -199,6 +199,15 @@ int main(int argc, char** argv)
                 exit(1);
             }
         }
+        else
+        {
+            // Default mode is operation
+            opt.bm_mode = PiBench::mode_t::Operation;
+
+            // Parse "num_operations"
+            if (result.count("operations"))
+                opt.num_ops = result["operations"].as<uint64_t>();
+        }
 
         // Parse "seconds"
         if (result.count("seconds"))


### PR DESCRIPTION
In the current implementation, if -m hadn't been provided, we would not have parsed -p/--operations, and num_ops would have been left default (which is 1e6). This PR adds that parsing back.

If the mode is not specified, for the sake of backward compatibility with legacy benchmarking scripts, we set the mode to operation-based and parse the number of operations if provided.